### PR TITLE
Issue 37: refactor puppet_conf_rb to handle different scenarios of reading puppet.conf

### DIFF
--- a/data/nodes/lightweight_component.yaml
+++ b/data/nodes/lightweight_component.yaml
@@ -1,6 +1,6 @@
 ---
 # ssh
-simple_grid::nodes::lightweight_component::installation_helper::ssh_config::ssh_authorized_keys_path: '/root/.ssh/authorized_keys'
+simple_grid::nodes::lightweight_component::ssh_config::ssh_authorized_keys_path: '/root/.ssh/authorized_keys'
 # puppet agent
 simple_grid::nodes::lightweight_component::puppet_conf: '/etc/puppetlabs/puppet/puppet.conf'
 simple_grid::nodes::lightweight_component::installation_helper::reset_agent::puppet_conf_path: '/etc/puppetlabs/puppet/puppet.conf'

--- a/data/nodes/lightweight_component.yaml
+++ b/data/nodes/lightweight_component.yaml
@@ -1,6 +1,7 @@
 ---
 # ssh
-simple_grid::nodes::lightweight_component::ssh_config::ssh_authorized_keys_path: '/root/.ssh/authorized_keys'
+simple_grid::nodes::lightweight_component::ssh_config::dir: '/root/.ssh'
+simple_grid::nodes::lightweight_component::ssh_config::ssh_authorized_keys_path: "%{hiera('simple_grid::nodes::lightweight_component::ssh_config::dir')}/authorized_keys"
 # puppet agent
 simple_grid::nodes::lightweight_component::puppet_conf: '/etc/puppetlabs/puppet/puppet.conf'
 simple_grid::nodes::lightweight_component::installation_helper::reset_agent::puppet_conf_path: '/etc/puppetlabs/puppet/puppet.conf'

--- a/lib/facter/puppet_conf.rb
+++ b/lib/facter/puppet_conf.rb
@@ -1,0 +1,15 @@
+Facter.add('puppet_conf') do
+  setcode do
+    begin
+      _output = String.new
+      File.open("/etc/puppetlabs/puppet/puppet.conf", 'r') do |f|
+        f.each_line do |line|
+          _output << line.gsub("\n", "") << "; "
+        end
+      end
+      _output
+    rescue Exception => ex
+      ex.class
+    end
+  end
+end

--- a/lib/puppet/functions/simple_grid/deserialize_puppet_conf.rb
+++ b/lib/puppet/functions/simple_grid/deserialize_puppet_conf.rb
@@ -1,0 +1,21 @@
+Puppet::Functions.create_function(:'simple_grid::deserialize_puppet_conf') do
+    dispatch :deserialize_puppet_conf do
+        param 'String', :puppetfile
+    end
+    def deserialize_puppet_conf(puppetfile)
+        _data = Hash.new
+        section_key = ""
+        File.open(puppetfile, "r").each do |line|
+            if line.include? "["
+                section_key = line.strip
+                _data.update(section_key => {})
+            elsif line.include? "="
+                split_data = line.split('=')
+                key = split_data[0].strip
+                value = split_data[1].strip
+                _data[section_key].update(key => value)
+            end
+        end
+        _data
+    end
+end

--- a/lib/puppet/functions/simple_grid/puppet_conf_editor.rb
+++ b/lib/puppet/functions/simple_grid/puppet_conf_editor.rb
@@ -1,20 +1,19 @@
 Puppet::Functions.create_function(:'simple_grid::puppet_conf_editor') do
     dispatch :edit_puppet_conf do
-        param 'String', :puppetfile
-        param 'String', :section
-        param 'String', :key
-        param 'String', :value
-        param 'Boolean', :write_file
+        param 'Hash', :puppetfile_data
+        param 'Hash', :data
     end
-    def edit_puppet_conf(puppetfile, section, key, value, write_file)
-        _data = deserialize(puppetfile)  
-        _section_name = "[" + section + "]"
-        _output = "False"
-        if !(_data.keys.include? _section_name)
-            _data.update(_section_name => Hash.new)
-        end
-        _data[_section_name].update( key => value)
-        serialize(puppetfile, _data, write_file)
+    def edit_puppet_conf(puppetfile_data, data)
+        data.each do |section_name, key_value|
+            _section_name = "[" + section_name + "]"
+            if !(puppetfile_data.keys.include? _section_name)
+                puppetfile_data.update(_section_name => Hash.new)
+            end
+            key_value.each do |key, value|
+                puppetfile_data[_section_name].update(key => value)
+            end   
+        end 
+        puppetfile_data
     end
 
     def deserialize(puppetfile)

--- a/lib/puppet/functions/simple_grid/puppet_conf_from_fact.rb
+++ b/lib/puppet/functions/simple_grid/puppet_conf_from_fact.rb
@@ -1,0 +1,21 @@
+Puppet::Functions.create_function(:'simple_grid::puppet_conf_from_fact') do
+    dispatch :puppet_conf_from_fact do
+        param 'String', :puppetfile_content
+    end
+    def puppet_conf_from_fact(puppetfile_content)
+        _output_array = puppetfile_content.split(";")
+        _data = Hash.new
+        _output_array.each do |line|
+            if line.include? "["
+                section_key = line.strip
+                _data.update(section_key => {})
+            # elsif line.include? "="
+            #     split_data = line.split('=')
+            #     key = split_data[0].strip
+            #     value = split_data[1].strip
+            #     _data[section_key].update(key => value)
+            end
+        end
+        _data
+    end
+end

--- a/lib/puppet/functions/simple_grid/puppet_conf_from_fact.rb
+++ b/lib/puppet/functions/simple_grid/puppet_conf_from_fact.rb
@@ -5,15 +5,16 @@ Puppet::Functions.create_function(:'simple_grid::puppet_conf_from_fact') do
     def puppet_conf_from_fact(puppetfile_content)
         _output_array = puppetfile_content.split(";")
         _data = Hash.new
+        _section_key = String.new
         _output_array.each do |line|
             if line.include? "["
-                section_key = line.strip
-                _data.update(section_key => {})
-            # elsif line.include? "="
-            #     split_data = line.split('=')
-            #     key = split_data[0].strip
-            #     value = split_data[1].strip
-            #     _data[section_key].update(key => value)
+                _section_key = line.strip
+                _data.update(_section_key => {})
+            elsif line.include? "="
+                split_data = line.split('=')
+                key = split_data[0].strip
+                value = split_data[1].strip
+                _data[_section_key].update(key => value)
             end
         end
         _data

--- a/lib/puppet/functions/simple_grid/serialize_puppet_conf.rb
+++ b/lib/puppet/functions/simple_grid/serialize_puppet_conf.rb
@@ -1,0 +1,15 @@
+Puppet::Functions.create_function(:'simple_grid::serialize_puppet_conf') do
+    dispatch :serialize_puppet_conf do
+        param 'Hash', :puppetfile_content
+    end
+    def serialize_puppet_conf(puppetfile_content)
+        _output = String.new
+        puppetfile_content.each do |section, section_content| 
+            _output << section << "\n"
+            section_content.each do |key, value|
+                _output << key << " = " << value << "\n" 
+            end
+        end
+        _output
+    end
+end

--- a/manifests/components/ccm.pp
+++ b/manifests/components/ccm.pp
@@ -61,7 +61,8 @@ class simple_grid::components::ccm::installation_helper::puppet_agent(
       "server"      => "${fqdn}"
     }
   }
-  $puppet_conf_content = simple_grid::puppet_conf_editor($puppet_conf_data, $puppet_conf_updates)
+  $puppet_conf_content_hash = simple_grid::puppet_conf_editor($puppet_conf_data, $puppet_conf_updates)
+  $puppet_conf_content = simple_grid::serialize_puppet_conf($puppet_conf_content_hash)
   file {"Update puppet conf":
     path => "${puppet_conf}",
     content => $puppet_conf_content

--- a/manifests/components/ccm.pp
+++ b/manifests/components/ccm.pp
@@ -171,7 +171,7 @@ class simple_grid::components::ccm::installation_helper::reset_agent(
   $runinterval,
   $puppet_conf = lookup('simple_grid::nodes::lightweight_component::puppet_conf'),
 ) {
-  $puppet_conf_data = simple_grid::deserialize_puppet_conf("${puppet_conf}")
+  $puppet_conf_data = simple_grid::puppet_conf_from_fact($facts["puppet_conf"])
   notify{"data was ${puppet_conf_data}":}
   $puppet_conf_updates = {
     "agent" => {

--- a/manifests/components/ccm.pp
+++ b/manifests/components/ccm.pp
@@ -92,22 +92,12 @@ class simple_grid::components::ccm::installation_helper::ssh_config::config_mast
 ){
   ssh_keygen{'root':
     filename => "${ssh_dir}/${ssh_host_key}"
+  } ~> 
+  exec {'Copying ssh host public key to fileserver':
+    command => "cp ${ssh_dir}/${ssh_host_key}.pub ${simple_config_dir}/",
+    path    => "/usr/local/bin/:/usr/bin/:/bin/"
   }
-  file {'Checking presence of ssh host private key for config master':
-    ensure => present,
-    path   => "${ssh_dir}/${ssh_host_key}",
-    mode   => "600",
-  }
-  file {'Checking presence of ssh host public key for config dir':
-    ensure => present,
-    path   => "${ssh_dir}/${ssh_host_key}.pub",
-    mode   => "644"
-  }
-  file {'Copy ssh host public key to simple config dir':
-    ensure => present,
-    source => "${ssh_dir}/${ssh_host_key}.pub",
-    path   => "${simple_config_dir}/${ssh_host_key}.pub"
-  }
+
 }
 
 #####################################################
@@ -135,7 +125,7 @@ class simple_grid::components::ccm::installation_helper::ssh_config::lightweight
     # TODO ensure you do not keep adding keys on each run
     file_line {'append public key':
       path => "${ssh_authorized_keys_path}",
-      line => "${simple_config_dir}/${ssh_host_key}.pub,
+      line => file("${simple_config_dir}/${ssh_host_key}.pub"),
     }
     sshd_config {'Permit Root Login for Puppet Bolt to run Tasks':
       key    => "PermitRootLogin",

--- a/manifests/config/config_master/init.pp
+++ b/manifests/config/config_master/init.pp
@@ -16,8 +16,8 @@ class simple_grid::config::config_master::init(
   class{"simple_grid::components::yaml_compiler::install":}
   notify{"Executing YAML Compiler":}
   class{"simple_grid::components::yaml_compiler::execute":}
-  notify{"Aggregate lifecycle callback scripts":}
-  class{"simple_grid::ccm_function::aggregate_repository_lifecycle_scripts":}
+  #notify{"Aggregate lifecycle callback scripts":}
+  #class{"simple_grid::ccm_function::aggregate_repository_lifecycle_scripts":}
 
   
 }

--- a/manifests/install/lightweight_component/simple_installer.pp
+++ b/manifests/install/lightweight_component/simple_installer.pp
@@ -1,5 +1,5 @@
 # Run command 
-#puppet apply --modulepath /etc/puppetlabs/code/environments/production/modules -e 'class {"simple_grid::install::lightweight_component::simple_installer":puppet_master => "basic_config_master.cern.ch"}'
+#puppet apply --modulepath /etc/puppetlabs/code/environments/production/modules -e "class {'simple_grid::install::lightweight_component::simple_installer':puppet_master => 'basic_config_master.cern.ch'}"
 
 class simple_grid::install::lightweight_component::simple_installer(  
   $puppet_master,
@@ -9,7 +9,7 @@ class simple_grid::install::lightweight_component::simple_installer(
   class {'simple_grid::ccm_function::create_config_dir':}
   
   class{"simple_grid::components::ccm::installation_helper::init_agent":
-    puppet_master => "${puppet_master}"",
+    puppet_master => "${puppet_master}",
   }
   
 }

--- a/manifests/nodes/lightweight_component/init.pp
+++ b/manifests/nodes/lightweight_component/init.pp
@@ -1,5 +1,4 @@
 class simple_grid::nodes::lightweight_component::init(
-  $node
 ){
   class {"simple_grid::components::ccm::config":
     node_type => "LC"

--- a/manifests/nodes/lightweight_component/init.pp
+++ b/manifests/nodes/lightweight_component/init.pp
@@ -1,0 +1,7 @@
+class simple_grid::nodes::lightweight_component::init(
+  $node
+){
+  class {"simple_grid::components::ccm::config":
+    node_type => "LC"
+  }
+}


### PR DESCRIPTION
For LC, use $facts['puppet_conf']
For CM, directly read the puppet.conf file